### PR TITLE
Add q-readings shortcode to list readings by essay or for the whole book

### DIFF
--- a/layouts/shortcodes/q-readings.html
+++ b/layouts/shortcodes/q-readings.html
@@ -1,0 +1,52 @@
+{{/*
+
+This shortcode creates a list of suggested readings, from a readings.yml file. The "range" value can either be "essay" to display only the readings for the essay where the shortcode appears, or "all" to display a list of readings for the whole book, organized by essay.
+
+*/}}
+{{- $range := "" -}}
+{{- with (.Get "range") }}{{ $range = . }}{{ end -}}
+
+{{- if eq $range "essay" -}}
+
+  {{- $essay := "" -}}
+  {{- $essay = .Page.File.BaseFileName -}}
+
+  <ul class="readings">
+  {{- range where .Site.Data.readings.entries "essay" $essay -}}
+  <li>{{ .full | markdownify }}</li>
+  {{- end -}}
+  </ul>
+
+{{- else -}}
+
+  {{- $pages := "" -}}
+  {{- $pages = where .Site.Pages ".Kind" "page" -}}
+  {{- $pages = where $pages ".Type" "!=" "data" -}}
+  {{- if eq .Site.Params.pdf true -}}
+    {{- $pages = where $pages "Params.pdf" "!=" "false" -}}
+  {{- else if eq .Site.Params.epub true -}}
+    {{- $pages = where $pages "Params.epub" "!=" "false" -}}
+  {{- else -}}
+    {{- $pages = where $pages "Params.online" "!=" "false" -}}
+  {{- end -}}
+
+  <ul class="readings">
+  {{- range $pages -}}
+  {{- $essay := "" -}}
+  {{- $essay := .Page.File.BaseFileName -}}
+  {{- $readings := where .Site.Data.readings.entries "essay" $essay -}}
+
+  {{- if gt (len $readings) 0 -}}
+
+    <li><strong>{{ if .Page.Params.label }}{{ .Page.Params.label }}{{ .Site.Params.pageLabelDivider }}{{ end }}{{ partial "page-title.html" . }}</strong><a href="{{ .Permalink }}" class="link-icon">{{ partial "icon.html" (dict "type" "link" "description" "Go to essay") }}</a>
+      <ul>
+    {{- range $readings -}}
+    <li>{{ .full | markdownify }}</li>
+    {{- end -}}
+      </ul></li>
+    {{- end -}}
+
+  {{- end -}}
+  </ul>
+
+{{- end -}}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,24 @@
+:root {
+  --accent-color: #CF4747; /* Should match $accent-color in variables.scss */
+}
+
+/* q-readings SHORTCODE */
+.quire-page__content .content ul.readings,
+.quire-page__content .content ul.readings li,
+.quire-page__content .content ul.readings li ul {
+  margin-left: 0;
+}
+.quire-page__content .content ul.readings li::before {
+  content: "";
+}
+.quire-page__content .content ul.readings .link-icon,
+.quire-page__content .content ul.readings .link-icon:hover {
+  border-bottom-width: 0 !important;
+}
+.quire-page__content .content ul.readings .link-icon svg {
+  height: .75em;
+  width: .75em;
+}
+.quire-page__content .content ul.readings .link-icon:hover svg {
+  fill: var(--accent-color);
+}


### PR DESCRIPTION
For this shortcode to work, all the essay tags in readings.yml will need to be lowercase to exactly match their filename. For example `essay: "01-Appiah"` will instead need to be `essay: "01-appiah"`. (Sorry!)

For the essays, the shortcode would be included as:

```
{{< q-readings range="essay" >}}
```

For the Suggested Readings page use:

```
{{< q-readings range="all" >}}
```
When  the `range` is set to "all", the readings are organized by essay and I've included the page label, title and subtitle, along with a small link icon that will go back to the page in question. This display can be modified as needed. Laura might perhaps want the author names included as well, or perhaps we should only use the essay numbers, or whatever.

Also, the readings are displayed in the order they are included in readings.yml. This is the default behavior and, I realized, the only thing that will work. We can't alphabetize based on the `full` entries, as they're not listed last name first. 
