### PR TITLE
Hide author names in bios on essay pages

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -22,3 +22,8 @@
 .quire-page__content .content ul.readings .link-icon:hover svg {
   fill: var(--accent-color);
 }
+
+/* Hide author name in bios on essay pages */
+.quire-page__content .content .backmatter .quire-contributors-list.bio .title {
+  display: none;
+}


### PR DESCRIPTION
Rather than adjust the size, I just removed the name altogether since it's fairly redundant with the bio itself, and there aren't more than one or two authors per essay for readers to have to scan through. I left the names headings as is on the Contributors page.

Closes issue #10.